### PR TITLE
Use worker thread for simulation loop

### DIFF
--- a/server/src/sim_worker.js
+++ b/server/src/sim_worker.js
@@ -1,0 +1,41 @@
+const { parentPort } = require('worker_threads');
+const CONFIG = require('./config');
+const { initState, saveState, getPublicState, getPublicParams, updateState } = require('./state');
+const { placeFood } = require('./actions');
+
+async function main() {
+  await initState();
+  parentPort.postMessage({ type: 'ready', params: getPublicParams(), state: getPublicState() });
+
+  while (true) {
+    const start = performance.now();
+    await updateState();
+    parentPort.postMessage({ type: 'state', state: getPublicState() });
+
+    const elapsed = performance.now() - start;
+    const sleepTime = Math.max(0, CONFIG.STATE_UPDATE_INTERVAL - elapsed);
+    await new Promise(r => setTimeout(r, sleepTime));
+  }
+}
+
+parentPort.on('message', async (msg) => {
+  if (!msg || !msg.type) return;
+  switch (msg.type) {
+    case 'placeFood':
+      try {
+        placeFood(msg.x, msg.y);
+        parentPort.postMessage({ type: 'placeFoodResult', requestId: msg.requestId, success: true });
+      } catch (err) {
+        parentPort.postMessage({ type: 'placeFoodResult', requestId: msg.requestId, success: false, error: err.message });
+      }
+      break;
+    case 'save':
+      saveState();
+      break;
+    case 'shutdown':
+      saveState();
+      process.exit(0);
+  }
+});
+
+main();


### PR DESCRIPTION
## Summary
- move main simulation loop to a worker thread to keep the event loop responsive
- proxy state updates and actions between the server and worker

## Testing
- `npm test` *(fails: Error: no test specified)*
- `python -m py_compile ai_server/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6857f368da708321ac179d331f72a111