### PR TITLE
Add Jest test suite

### DIFF
--- a/services/web_server/package.json
+++ b/services/web_server/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest --coverage"
   },
   "keywords": [],
   "author": "",
@@ -16,5 +16,12 @@
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "ws": "^8.18.1"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }

--- a/services/web_server/src/server.js
+++ b/services/web_server/src/server.js
@@ -70,15 +70,17 @@ async function loop() {
     }
 }
 
-server.listen(CONFIG.PORT, async () => {
-    console.log(`Server running at http://localhost:${CONFIG.PORT}`);
-    await initState();
-    loop();
+function startServer(port = CONFIG.PORT) {
+    server.listen(port, async () => {
+        console.log(`Server running at http://localhost:${port}`);
+        await initState();
+        loop();
 
-    if (CONFIG.STATE_SAVE_INTERVAL !== null) {
-        setInterval(saveState, CONFIG.STATE_SAVE_INTERVAL);
-    }
-});
+        if (CONFIG.STATE_SAVE_INTERVAL !== null) {
+            setInterval(saveState, CONFIG.STATE_SAVE_INTERVAL);
+        }
+    });
+}
 
 function gracefulShutdown() {
     console.log("Shutting down gracefully...");
@@ -100,3 +102,9 @@ function gracefulShutdown() {
 
 process.on("SIGINT", gracefulShutdown);
 process.on("SIGTERM", gracefulShutdown);
+
+module.exports = { app, startServer };
+
+if (require.main === module) {
+    startServer();
+}

--- a/services/web_server/tests/integration/health.test.js
+++ b/services/web_server/tests/integration/health.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const { app } = require('../../src/server');
+
+describe('GET /api/health', () => {
+  it('returns OK status', async () => {
+    const res = await request(app).get('/api/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'OK' });
+  });
+});

--- a/services/web_server/tests/integration/place-food.test.js
+++ b/services/web_server/tests/integration/place-food.test.js
@@ -1,0 +1,24 @@
+const request = require('supertest');
+const actions = require('../../src/actions');
+const { app } = require('../../src/server');
+
+jest.mock('../../src/actions');
+
+describe('POST /api/place-food', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('responds with success when action succeeds', async () => {
+    actions.placeFood.mockImplementation(() => {});
+    const res = await request(app).post('/api/place-food').send({ x: 1, y: 2 });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+    expect(actions.placeFood).toHaveBeenCalledWith(1, 2);
+  });
+
+  it('responds with error when action throws', async () => {
+    actions.placeFood.mockImplementation(() => { throw new Error('bad'); });
+    const res = await request(app).post('/api/place-food').send({ x: 1, y: 2 });
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'bad' });
+  });
+});

--- a/services/web_server/tests/unit/creature.test.js
+++ b/services/web_server/tests/unit/creature.test.js
@@ -1,0 +1,13 @@
+const { getScore } = require('../../src/creature');
+
+describe('getScore', () => {
+  it('calculates food per turn', () => {
+    const creature = { stats: { totalFoodCollected: 4, turnsSurvived: 2 } };
+    expect(getScore(creature)).toBeCloseTo(2);
+  });
+
+  it('uses one turn minimum to avoid division by zero', () => {
+    const creature = { stats: { totalFoodCollected: 3, turnsSurvived: 0 } };
+    expect(getScore(creature)).toBeCloseTo(3);
+  });
+});

--- a/services/web_server/tests/unit/grid.test.js
+++ b/services/web_server/tests/unit/grid.test.js
@@ -1,0 +1,23 @@
+const { isCellOccupied, isWithinRadius } = require('../../src/grid');
+
+describe('isCellOccupied', () => {
+  it('returns true when food occupies cell', () => {
+    const state = { food: [{ x: 1, y: 2 }], obstacles: [] };
+    expect(isCellOccupied(1, 2, state)).toBe(true);
+  });
+
+  it('returns false for empty cell', () => {
+    const state = { food: [], obstacles: [] };
+    expect(isCellOccupied(0, 0, state)).toBe(false);
+  });
+});
+
+describe('isWithinRadius', () => {
+  it('true when point inside radius', () => {
+    expect(isWithinRadius(0, 0, 1, 1, 5)).toBe(true);
+  });
+
+  it('false when point outside radius', () => {
+    expect(isWithinRadius(0, 0, 3, 4, 9)).toBe(false);
+  });
+});

--- a/services/web_server/tests/unit/nn.test.js
+++ b/services/web_server/tests/unit/nn.test.js
@@ -1,0 +1,25 @@
+const axios = require('axios');
+const CONFIG = require('../../src/config');
+const { mutateWeights } = require('../../src/nn');
+
+jest.mock('axios');
+
+describe('mutateWeights', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns mutated weights on success', async () => {
+    axios.post.mockResolvedValue({ data: { weights: [2, 3] } });
+    await expect(mutateWeights([1])).resolves.toEqual([2, 3]);
+    expect(axios.post).toHaveBeenCalledWith(
+      CONFIG.NN_SERVICE_URL + '/weights/mutate',
+      { weights: [1] }
+    );
+  });
+
+  it('throws when request fails', async () => {
+    axios.post.mockRejectedValue(new Error('network'));
+    await expect(mutateWeights([1])).rejects.toThrow('network');
+  });
+});

--- a/services/web_server/tests/unit/performance.test.js
+++ b/services/web_server/tests/unit/performance.test.js
@@ -1,0 +1,22 @@
+const CONFIG = require('../../src/config');
+const { appendTopPerformers } = require('../../src/performance');
+
+describe('appendTopPerformers', () => {
+  it('adds creature and sorts by score', () => {
+    const state = { topPerformers: [] };
+    const a = { stats: { totalFoodCollected: 2, turnsSurvived: 1 } };
+    const b = { stats: { totalFoodCollected: 1, turnsSurvived: 1 } };
+    appendTopPerformers(a, state);
+    appendTopPerformers(b, state);
+    expect(state.topPerformers[0]).toBe(a);
+    expect(state.topPerformers.length).toBe(2);
+  });
+
+  it('trims performers list to configured maximum', () => {
+    const state = { topPerformers: [] };
+    for (let i = 0; i < CONFIG.TOP_PERFORMERS_COUNT + 2; i++) {
+      appendTopPerformers({ stats: { totalFoodCollected: i + 1, turnsSurvived: 1 } }, state);
+    }
+    expect(state.topPerformers.length).toBeLessThanOrEqual(CONFIG.TOP_PERFORMERS_COUNT);
+  });
+});


### PR DESCRIPTION
## Summary
- export Express app from `server.js` and provide `startServer` for normal runs
- configure Jest and Supertest in `package.json`
- add unit tests for grid, creature, performance and neural network helpers
- add integration tests for health check and place-food routes

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68616ac347c483219e97432b667876d3