### PR TITLE
Improve error handling in NN service

### DIFF
--- a/services/web_server/src/nn.js
+++ b/services/web_server/src/nn.js
@@ -3,17 +3,26 @@ const CONFIG = require("./config");
 const { getVisibleFood, getVisibleObstacles, getVisibleCreatures } = require("./grid");
 
 async function initWeights() {
-    const response = await axios.get(CONFIG.NN_SERVICE_URL + "/weights/init");
-    return response.data.weights;
+    try {
+        const response = await axios.get(CONFIG.NN_SERVICE_URL + "/weights/init");
+        return response.data.weights;
+    } catch (err) {
+        throw new Error('Failed to initialize weights: ' + err.message);
+    }
 }
 
 async function mutateWeights(weights) {
-    const response = await axios.post(CONFIG.NN_SERVICE_URL + "/weights/mutate", { weights });
-    return response.data.weights;
+    try {
+        const response = await axios.post(CONFIG.NN_SERVICE_URL + "/weights/mutate", { weights });
+        return response.data.weights;
+    } catch (err) {
+        throw new Error('Failed to mutate weights: ' + err.message);
+    }
 }
 
 async function getMovements(state) {
-    const response = await axios.post(CONFIG.NN_SERVICE_URL + "/think", {
+    try {
+        const response = await axios.post(CONFIG.NN_SERVICE_URL + "/think", {
         creatures: state.creatures.map(c => ({
             id: c.id,
             x: c.x,
@@ -36,9 +45,12 @@ async function getMovements(state) {
         maxEnergy: state.params.maxEnergy,
         maxTurnAngle: state.params.maxTurnAngle,
         maxSpeed: state.params.maxSpeed
-    });
+        });
 
-    return response.data.movements;
+        return response.data.movements;
+    } catch (err) {
+        throw new Error('Failed to fetch movements: ' + err.message);
+    }
 }
 
 module.exports = {

--- a/services/web_server/tests/unit/nn.test.js
+++ b/services/web_server/tests/unit/nn.test.js
@@ -1,8 +1,14 @@
 const axios = require('axios');
 const CONFIG = require('../../src/config');
-const { mutateWeights } = require('../../src/nn');
+const { initWeights, mutateWeights, getMovements } = require('../../src/nn');
+const grid = require('../../src/grid');
 
 jest.mock('axios');
+jest.mock('../../src/grid', () => ({
+  getVisibleFood: jest.fn(() => []),
+  getVisibleObstacles: jest.fn(() => []),
+  getVisibleCreatures: jest.fn(() => [])
+}));
 
 describe('mutateWeights', () => {
   afterEach(() => {
@@ -20,6 +26,91 @@ describe('mutateWeights', () => {
 
   it('throws when request fails', async () => {
     axios.post.mockRejectedValue(new Error('network'));
-    await expect(mutateWeights([1])).rejects.toThrow('network');
+    await expect(mutateWeights([1])).rejects.toThrow('Failed to mutate weights: network');
+  });
+});
+
+describe('initWeights', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns weights on success', async () => {
+    axios.get.mockResolvedValue({ data: { weights: [5, 6] } });
+    await expect(initWeights()).resolves.toEqual([5, 6]);
+    expect(axios.get).toHaveBeenCalledWith(CONFIG.NN_SERVICE_URL + '/weights/init');
+  });
+
+  it('throws when request fails', async () => {
+    axios.get.mockRejectedValue(new Error('timeout'));
+    await expect(initWeights()).rejects.toThrow('Failed to initialize weights: timeout');
+  });
+});
+
+describe('getMovements', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const baseState = {
+    creatures: [
+      {
+        id: 1,
+        x: 0,
+        y: 0,
+        angle: 0,
+        energy: 10,
+        prev: { x: 0, y: 0, angle: 0, energy: 10 },
+        recentPath: [],
+        justReproduced: false,
+        weights: []
+      }
+    ],
+    params: {
+      gridSize: 1,
+      visibilityRadius: 2,
+      maxEnergy: 3,
+      maxTurnAngle: 4,
+      maxSpeed: 5
+    }
+  };
+
+  it('returns movements on success', async () => {
+    axios.post.mockResolvedValue({ data: { movements: [{ angleDelta: 0, speed: 1 }] } });
+    await expect(getMovements(baseState)).resolves.toEqual([{ angleDelta: 0, speed: 1 }]);
+    expect(axios.post).toHaveBeenCalledWith(
+      CONFIG.NN_SERVICE_URL + '/think',
+      {
+        creatures: [
+          {
+            id: 1,
+            x: 0,
+            y: 0,
+            angle: 0,
+            energy: 10,
+            prevX: 0,
+            prevY: 0,
+            prevAngle: 0,
+            recentPath: [],
+            prevEnergy: 10,
+            justReproduced: false,
+            weights: [],
+            food: [],
+            obstacles: [],
+            creatures: []
+          }
+        ],
+        gridSize: 1,
+        visibilityRadius: 2,
+        maxEnergy: 3,
+        maxTurnAngle: 4,
+        maxSpeed: 5
+      }
+    );
+  });
+
+  it('throws when request fails', async () => {
+    axios.post.mockRejectedValue(new Error('down'));
+    await expect(getMovements(baseState)).rejects.toThrow('Failed to fetch movements: down');
   });
 });


### PR DESCRIPTION
## Summary
- add error wrappers around axios requests in `nn.js`
- extend tests for `initWeights`, `mutateWeights`, and `getMovements` to check failures

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617da8ff188321b1edb1e8664229db