### PR TITLE
Fix boundary collision damage

### DIFF
--- a/services/web_server/src/state.js
+++ b/services/web_server/src/state.js
@@ -211,8 +211,8 @@ function handleObstacleCollision(creature) {
         creature._collisionOccurred = true;
     }
 
-    creature.x = Math.max(0, Math.min(CONFIG.GRID_SIZE - 1, newX));
-    creature.y = Math.max(0, Math.min(CONFIG.GRID_SIZE - 1, newY));
+    creature.x = Math.max(0, Math.min(CONFIG.GRID_SIZE, newX));
+    creature.y = Math.max(0, Math.min(CONFIG.GRID_SIZE, newY));
 
     return creature;
 }


### PR DESCRIPTION
## Summary
- allow positions close to grid edges instead of clamping to integer cell limits

## Testing
- `npm test --silent` *(fails: jest not found)*
- `python3 -m pytest -q` *(fails: ModuleNotFoundError: 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68619cc0d3a08321b21e2d3e181797e2