### PR TITLE
Fix sed delimiter for all injections

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,7 +96,7 @@ jobs:
         run: |
           INDEX_FILE=services/web_server/public/index.html
           TAG="<link rel=\"canonical\" href=\"$CANONICAL_URL\">"
-          sed -i "s|<!-- __CANONICAL_URL__ -->|$TAG|" "$INDEX_FILE"
+          sed -i "s#<!-- __CANONICAL_URL__ -->#$TAG#" "$INDEX_FILE"
 
       - name: Inject GA tag into index.html
         if: github.ref_name == 'main' && vars.GA_TAG_ID != ''
@@ -105,13 +105,13 @@ jobs:
         run: |
           INDEX_FILE=services/web_server/public/index.html
           GA_TAG="<script async src=\"https://www.googletagmanager.com/gtag/js?id=$GA_TAG_ID\"></script><script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','$GA_TAG_ID');</script>"
-          sed -i "s|<!-- __GA_TAG_SCRIPT__ -->|$GA_TAG|" "$INDEX_FILE"
+          sed -i "s#<!-- __GA_TAG_SCRIPT__ -->#$GA_TAG#" "$INDEX_FILE"
 
       - name: Inject robots meta tag for non-prod
         if: github.ref_name != 'main'
         run: |
           INDEX_FILE=services/web_server/public/index.html
-          sed -i "s|<!-- __ROBOTS_TAG__ -->|<meta name=\"robots\" content=\"noindex, nofollow, noarchive, nosnippet\">|" "$INDEX_FILE"
+          sed -i "s#<!-- __ROBOTS_TAG__ -->#<meta name=\"robots\" content=\"noindex, nofollow, noarchive, nosnippet\">#" "$INDEX_FILE"
 
       - name: Build and start containers
         uses: appleboy/ssh-action@v0.1.10


### PR DESCRIPTION
## Summary
- update sed commands in deploy workflow to use `#` delimiter to avoid conflicts with pipe characters

## Testing
- `python3 -m pytest tests` (nn_service)
- `npm test` (web_server)


------
https://chatgpt.com/codex/tasks/task_e_687dd35718a483218549343c52a30896