### PR TITLE
Fix splash screen handling

### DIFF
--- a/services/web_server/public/index.html
+++ b/services/web_server/public/index.html
@@ -26,7 +26,7 @@
     <link rel="icon" type="image/png" sizes="48x48" href="icons/icon-48x48.png">
     <link rel="apple-touch-icon" sizes="180x180" href="icons/apple-touch-icon.png">
     <link rel="apple-touch-startup-image" href="icons/apple-splash-1170x2532.png"
-        media="(device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3)" />
+        media="(device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)" />
     <link rel="icon" sizes="192x192" href="icons/icon-192x192.png">
     <link rel="icon" sizes="512x512" href="icons/icon-512x512.png">
     <link rel="manifest" href="manifest.json">


### PR DESCRIPTION
## Summary
- remove unused landscape startup image entry in web client

## Testing
- `npm test`
- `python3 -m pytest services/nn_service/tests` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687f3c9cb8b88321b5196a45969f858c