### PR TITLE
Format GA tag injection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,7 +85,16 @@ jobs:
           echo "Injecting GA tag: $GA_TAG_ID"
           INDEX_FILE=services/web_server/public/index.html
 
-          GA_TAG="<script async src=\"https://www.googletagmanager.com/gtag/js?id=$GA_TAG_ID\"></script><script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','${GA_TAG_ID}');</script>"
+          GA_TAG=$(cat <<EOF
+              <script async src="https://www.googletagmanager.com/gtag/js?id=$GA_TAG_ID"></script>
+              <script>
+                window.dataLayer=window.dataLayer||[];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '$GA_TAG_ID');
+              </script>
+          EOF
+          )
 
           awk -v replacement="$GA_TAG" '
             {


### PR DESCRIPTION
## Summary
- make the GA tag script injection multiline for better readability

## Testing
- `python3 -m pytest services/nn_service/tests` *(fails: ModuleNotFoundError: httpx)*
- `npm test` in `services/web_server`

------
https://chatgpt.com/codex/tasks/task_e_687f3ccb8e008321a57c2a9a6f6d68b8