### PR TITLE
Fix creature initialization and stabilize state loop

### DIFF
--- a/services/web_server/src/creature.js
+++ b/services/web_server/src/creature.js
@@ -2,30 +2,33 @@ const CONFIG = require("./config");
 const { initWeights } = require("./nn");
 const { getRandomEmptyCell } = require("./grid");
 
-async function initCreature(state, x = null, y = null, angle = 0.0, weights = null, generation = 1) {
+async function initCreature(state, x = null, y = null, angle = null, weights = null, generation = 1) {
     if (x === null || y === null) {
         const cell = getRandomEmptyCell(state);
-        x = cell.x;
-        y = cell.y;
-    } 
-    angle = angle !== null ? angle : (Math.random() * 2 * Math.PI) - Math.PI;
+        if (!cell) {
+            throw new Error("No empty cells available to place a creature");
+        }
+        ({ x, y } = cell);
+    }
+
+    const resolvedAngle = angle !== null ? angle : (Math.random() * 2 * Math.PI) - Math.PI;
 
     if (!weights) {
         weights = await initWeights();
     }
 
-    var creature = {
+    const creature = {
         id: getNextCreatureId(state),
         x,
         y,
-        angle,
+        angle: resolvedAngle,
         wanderAngle: (Math.random() * 2 * Math.PI) - Math.PI,
         wanderStrength: 1.0,
         energy: CONFIG.CREATURE_INITIAL_ENERGY,
         prev: {
             x,
             y,
-            angle,
+            angle: resolvedAngle,
             energy: CONFIG.CREATURE_INITIAL_ENERGY
         },
         recentPath: [{ x, y }],

--- a/services/web_server/tests/unit/creature.test.js
+++ b/services/web_server/tests/unit/creature.test.js
@@ -1,0 +1,47 @@
+const CONFIG = require('../../src/config');
+
+jest.mock('../../src/nn', () => ({
+  initWeights: jest.fn(() => Promise.resolve([1, 2, 3])),
+}));
+
+jest.mock('../../src/grid', () => ({
+  getRandomEmptyCell: jest.fn(() => ({ x: 4, y: 5 })),
+}));
+
+const { initCreature } = require('../../src/creature');
+const nn = require('../../src/nn');
+const grid = require('../../src/grid');
+
+describe('initCreature', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    if (Math.random.mockRestore) {
+      Math.random.mockRestore();
+    }
+  });
+
+  it('assigns a random heading when angle is not provided', async () => {
+    const randomValues = [0.75, 0.25];
+    jest.spyOn(Math, 'random').mockImplementation(() => randomValues.shift());
+    const state = { lastCreatureId: 0 };
+
+    const creature = await initCreature(state);
+
+    const expectedAngle = (0.75 * 2 * Math.PI) - Math.PI;
+    const expectedWander = (0.25 * 2 * Math.PI) - Math.PI;
+
+    expect(grid.getRandomEmptyCell).toHaveBeenCalledWith(state);
+    expect(nn.initWeights).toHaveBeenCalledTimes(1);
+    expect(creature.angle).toBeCloseTo(expectedAngle);
+    expect(creature.prev.angle).toBeCloseTo(expectedAngle);
+    expect(creature.wanderAngle).toBeCloseTo(expectedWander);
+    expect(creature.energy).toBe(CONFIG.CREATURE_INITIAL_ENERGY);
+  });
+
+  it('throws when the grid has no empty cells', async () => {
+    grid.getRandomEmptyCell.mockReturnValueOnce(null);
+    const state = { lastCreatureId: 0 };
+
+    await expect(initCreature(state)).rejects.toThrow('No empty cells available');
+  });
+});

--- a/services/web_server/tests/unit/state.test.js
+++ b/services/web_server/tests/unit/state.test.js
@@ -1,0 +1,113 @@
+const CONFIG = require('../../src/config');
+
+jest.mock('../../src/nn', () => ({
+  getMovements: jest.fn(),
+  mutateWeights: jest.fn(),
+}));
+
+const stateModule = require('../../src/state');
+const nn = require('../../src/nn');
+
+function createCreature(id, energy) {
+  return {
+    id,
+    x: id,
+    y: id,
+    angle: 0,
+    wanderAngle: 0,
+    wanderStrength: 1,
+    energy,
+    prev: { x: id, y: id, angle: 0, energy },
+    recentPath: [{ x: id, y: id }],
+    generation: 1,
+    justReproduced: false,
+    updatesToFlash: 0,
+    weights: [],
+    stats: { msLived: 0, energyGained: 0, score: 0 },
+  };
+}
+
+function createBaseState(creatures, overrides = {}) {
+  const { stats: statsOverrides, ...restOverrides } = overrides;
+  const stats = {
+    restarts: 0,
+    generation: CONFIG.FOOD_ENERGY_BONUS_MAX_GEN + 1,
+    creatureCount: creatures.length,
+    foodCount: 0,
+    ...statsOverrides,
+  };
+
+  return {
+    creatures,
+    food: [],
+    obstacles: [],
+    borderObstacles: [],
+    stats,
+    topPerformers: [],
+    lastCreatureId: Math.max(...creatures.map(c => c.id)),
+    ...restOverrides,
+  };
+}
+
+describe('updateState', () => {
+  afterEach(() => {
+    stateModule.__setStateForTesting(null);
+    jest.resetAllMocks();
+  });
+
+  it('tracks the actual energy gained from food consumption', async () => {
+    const initialEnergy = CONFIG.CREATURE_MAX_ENERGY - CONFIG.FOOD_ENERGY - 10;
+    const creatures = [
+      createCreature(1, initialEnergy),
+      createCreature(2, CONFIG.CREATURE_INITIAL_ENERGY),
+      createCreature(3, CONFIG.CREATURE_INITIAL_ENERGY),
+    ];
+    const state = createBaseState(creatures, {
+      food: [{ x: creatures[0].x, y: creatures[0].y }],
+      stats: { foodCount: 1 },
+    });
+
+    stateModule.__setStateForTesting(state);
+
+    nn.getMovements.mockResolvedValue([
+      { id: 1, angleDelta: 0, speed: 0 },
+      { id: 2, angleDelta: 0, speed: 0 },
+      { id: 3, angleDelta: 0, speed: 0 },
+    ]);
+
+    await stateModule.updateState();
+
+    const updated = state.creatures.find(c => c.id === 1);
+    const energyLoss = CONFIG.CREATURE_ENERGY_LOSS * CONFIG.CREATURE_ENERGY_LOSS_BASE;
+    const energyBeforeFood = initialEnergy - energyLoss;
+    const expectedEnergyAfterEating = energyBeforeFood + CONFIG.FOOD_ENERGY;
+    const expectedGain = expectedEnergyAfterEating - energyBeforeFood;
+
+    expect(updated.energy).toBeCloseTo(expectedEnergyAfterEating);
+    expect(updated.stats.energyGained).toBeCloseTo(expectedGain);
+  });
+
+  it('keeps creatures stable when the NN omits movement commands', async () => {
+    const startingEnergy = 500;
+    const creatures = [
+      createCreature(1, startingEnergy),
+      createCreature(2, startingEnergy),
+      createCreature(3, startingEnergy),
+    ];
+    const state = createBaseState(creatures);
+
+    stateModule.__setStateForTesting(state);
+
+    nn.getMovements.mockResolvedValue([
+      { id: 1, angleDelta: 0.1, speed: 0.2 },
+    ]);
+
+    await stateModule.updateState();
+
+    expect(state.creatures).toHaveLength(3);
+
+    const missingMovementCreature = state.creatures.find(c => c.id === 2);
+    const expectedEnergy = startingEnergy - (CONFIG.CREATURE_ENERGY_LOSS * CONFIG.CREATURE_ENERGY_LOSS_BASE);
+    expect(missingMovementCreature.energy).toBeCloseTo(expectedEnergy);
+  });
+});


### PR DESCRIPTION
## Summary
- randomize default creature headings, reuse spawn angles for previous state, and throw when no spawn cell is available
- sanitize neural-network movement data and correct food energy accounting while exposing helpers for tests
- add focused unit tests covering creature initialization and state update edge cases

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d06aeabde48321bdce09b51706bd7b